### PR TITLE
DigestMethod estava sendo gerado como SHA1

### DIFF
--- a/Certfly/Certfly.Assinar.cs
+++ b/Certfly/Certfly.Assinar.cs
@@ -144,7 +144,8 @@ namespace Certfly
              else
              {
                  reference.Uri = "#" + AAtributoId;
-             }           
+             }        
+            reference.DigestMethod = "http://www.w3.org/2001/04/xmlenc#sha256";
             reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
             reference.AddTransform(new XmlDsigC14NTransform(false));
             SignedDocument.AddReference(reference);


### PR DESCRIPTION
Ao enviar o evento ao eSocial o servidor estava acusando DigestMethod inválido.